### PR TITLE
Use np.allclose for comparison by default

### DIFF
--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -20,7 +20,7 @@ def _plot(
         logx=False,
         logy=False,
         automatic_order=True,
-        equality_check=lambda a, b: numpy.equal(a, b).all()
+        equality_check=numpy.allclose
         ):
     # Estimate the timer granularity by measuring a no-op.
     noop_time = timeit.repeat(stmt=lambda: None, repeat=10, number=100)


### PR DESCRIPTION
At least in my use, a large number of algorithms that I compare
are numpy or scipy based and deal with floating point numbers.
Using ``numpy.equal`` for correctloness testing is not an
ideal choice for those, because round-off
errors that are unavoidalbe in any algorithm trigger an Excpetion.
Thus, I suggest to use ``numpy.allclose`` as the default comparison
function. It's going to give the same results for integer operations
and it's a more forgiving for float operations.
Testing different algorithms for their stability to round-off errors
is a separate problem.

Here is an example:
```
In [12]: import numpy
    ...: from numpy.core.umath_tests import inner1d
    ...: import perfplot
    ...: 
    ...: perfplot.show(
    ...:         setup=lambda n: (numpy.random.rand(n, 3), numpy.random.rand(n, 
    ...: 3)),
    ...:         n_range=[2**k for k in range(1, 17)],
    ...:         kernels=[
    ...:             lambda data: numpy.sum(data[0] * data[1], axis=1),
    ...:             lambda data: numpy.einsum('ij, ij->i', data[0], data[1]),
    ...:             lambda data: inner1d(data[0], data[1])
    ...:             ],
    ...:         labels=['np.sum(a*b, axis=1)', 'einsum', 'inner1d'],
    ...:         logx=True,
    ...:         logy=True,
    ...:         )
    ...: 
  0%|                                                    | 0/16 [00:00<?, ?it/s]
---------------------------------------------------------------------------it/s]
AssertionError                            Traceback (most recent call last)
<ipython-input-12-75cd98a9ff76> in <module>()
     13         labels=['np.sum(a*b, axis=1)', 'einsum', 'inner1d'],
     14         logx=True,
---> 15         logy=True,
     16         )

/nfs/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/perfplot/main.pyc in show(*args, **kwargs)
      8 
      9 def show(*args, **kwargs):
---> 10     _plot(*args, **kwargs)
     11     plt.show()
     12     return

/nfs/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/perfplot/main.pyc in _plot(setup, kernels, n_range, labels, xlabel, repeat, logx, logy, automatic_order, equality_check)
     34         for k, kernel in enumerate(tqdm(kernels)):
     35             if equality_check:
---> 36                 assert equality_check(reference, kernel(out))
     37             # Make sure that the statement is executed at least so often that
     38             # the timing exceeds 1000 times the granularity of the clock.

AssertionError: 

```