### PR TITLE
fixed bug with 'func_name' attribute

### DIFF
--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -70,7 +70,7 @@ def _plot(
     T = numpy.min(timings, axis=2)
 
     if labels is None:
-        labels = [k.func_name for k in kernels]
+        labels = [k.__name__ for k in kernels]
 
     if automatic_order:
         # Sort T by the last entry. This makes the order in the legend


### PR DESCRIPTION
Using `__name__` is the preferred method as it applies uniformly. Unlike `func_name`, it works on built-in functions as well.
The problem arose when I tried to run your snippet https://stackoverflow.com/a/43096495/2840134. I suggest adding those examples to your testing pipeline.
Anyway, your lib is quite cute.