### PR TITLE
ENH: Handle KeyboardInterrupt to still generate perfplot

### DIFF
--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -94,48 +94,52 @@ def bench(setup, kernels, n_range,
     granularity = min(noop_time) / 100
 
     timings = numpy.empty((len(kernels), len(n_range), repeat))
-    for i, n in enumerate(tqdm(n_range)):
-        out = setup(n)
-        if equality_check:
-            reference = kernels[0](out)
-        for k, kernel in enumerate(tqdm(kernels)):
+    try:
+        for i, n in enumerate(tqdm(n_range)):
+            out = setup(n)
             if equality_check:
-                assert equality_check(reference, kernel(out)), \
-                    'Equality check fail. ({}, {})' \
-                    .format(labels[0], labels[k])
-            # Make sure that the statement is executed at least so often that
-            # the timing exceeds 1000 times the granularity of the clock.
-            number = 1
-            required_timing = 1000 * granularity
-            min_timing = 0.0
-            while min_timing <= required_timing:
-                timings[k, i] = timeit.repeat(
-                    # pylint: disable=cell-var-from-loop
-                    stmt=lambda: kernel(out),
-                    repeat=repeat,
-                    number=number
-                    )
-                min_timing = min(timings[k, i])
-                # print(timings[k, i])
-                # plt.semilogy(range(len(timings[k, i])), timings[k, i])
-                # plt.hist(timings[k, i])
-                # plt.show()
-                timings[k, i] /= number
-                # Adapt the number of runs for the next iteration such that the
-                # required_timing is just exceeded. If the required timing and
-                # minimal timing are just equal, `number` remains the same (up
-                # to an allowance of 0.2).
-                allowance = 0.2
-                max_factor = 100
-                # The next expression is
-                #   min(max_factor, required_timing / min_timing + allowance)
-                # with avoiding division by 0 if min_timing is too small.
-                factor = (
-                    required_timing / min_timing + allowance
-                    if min_timing > required_timing / (max_factor - allowance)
-                    else max_factor
-                    )
-                number = int(factor * number) + 1
+                reference = kernels[0](out)
+            for k, kernel in enumerate(tqdm(kernels)):
+                if equality_check:
+                    assert equality_check(reference, kernel(out)), \
+                        'Equality check fail. ({}, {})' \
+                        .format(labels[0], labels[k])
+                # Make sure that the statement is executed at least so often that
+                # the timing exceeds 1000 times the granularity of the clock.
+                number = 1
+                required_timing = 1000 * granularity
+                min_timing = 0.0
+                while min_timing <= required_timing:
+                    timings[k, i] = timeit.repeat(
+                        # pylint: disable=cell-var-from-loop
+                        stmt=lambda: kernel(out),
+                        repeat=repeat,
+                        number=number
+                        )
+                    min_timing = min(timings[k, i])
+                    # print(timings[k, i])
+                    # plt.semilogy(range(len(timings[k, i])), timings[k, i])
+                    # plt.hist(timings[k, i])
+                    # plt.show()
+                    timings[k, i] /= number
+                    # Adapt the number of runs for the next iteration such that the
+                    # required_timing is just exceeded. If the required timing and
+                    # minimal timing are just equal, `number` remains the same (up
+                    # to an allowance of 0.2).
+                    allowance = 0.2
+                    max_factor = 100
+                    # The next expression is
+                    #   min(max_factor, required_timing / min_timing + allowance)
+                    # with avoiding division by 0 if min_timing is too small.
+                    factor = (
+                        required_timing / min_timing + allowance
+                        if min_timing > required_timing / (max_factor - allowance)
+                        else max_factor
+                        )
+                    number = int(factor * number) + 1
+    except KeyboardInterrupt:
+        timings = timings[:, :i]
+        n_range = n_range[:i]
 
     # Only report the minimum time; everthing else just measures how slow the
     # system can go.


### PR DESCRIPTION
This adds a try..except statement to handle KeyboardInterrupt, allowing users to break out of perfplot runs and still generate a plot using whatever timings have been completed. Partial timings from the last iteration are discarded.