### PR TITLE
setups as list

### DIFF
--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -118,12 +118,15 @@ def bench(
     last_n = numpy.empty(len(kernels), dtype=int)
     last_total_time = numpy.empty(len(kernels))
 
+    stp_islist = True if isinstance(setup, (list, tuple)) else False
     try:
         for i, n in enumerate(tqdm(n_range)):
-            data = setup(n)
+            data = setup[0](n) if stp_islist else setup(n)
             if equality_check:
                 reference = kernels[0](data)
             for k, kernel in enumerate(tqdm(kernels)):
+                if stp_islist:
+                    data = setup[k](n)
                 if equality_check:
                     assert equality_check(
                         reference, kernel(data)

--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -118,7 +118,7 @@ def bench(
     last_n = numpy.empty(len(kernels), dtype=int)
     last_total_time = numpy.empty(len(kernels))
 
-    stp_islist = True if isinstance(setup, (list, tuple)) else False
+    stp_islist = isinstance(setup, (list, tuple))
     try:
         for i, n in enumerate(tqdm(n_range)):
             data = setup[0](n) if stp_islist else setup(n)

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -84,6 +84,7 @@ def test_no_labels():
 def test_mult_setup():
     def mytest(a):
         return numpy.c_[a, a]
+
     def mytest2(a):
         return numpy.stack([a, a]).T
 
@@ -101,8 +102,9 @@ def test_mult_setup():
     out = perfplot.bench(
         setup=setups, kernels=kernels, n_range=r, xlabel="len(a)", equality_check=None
     )
-    # out.show()
+    out.show()
     return
+
 
 def test_save():
     def mytest(a):

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -81,6 +81,29 @@ def test_no_labels():
     return
 
 
+def test_mult_setup():
+    def mytest(a):
+        return numpy.c_[a, a]
+    def mytest2(a):
+        return numpy.stack([a, a]).T
+
+    kernels = [mytest, mytest2]
+
+    def setup1(N):
+        return numpy.random.rand(N)
+
+    def setup2(N):
+        return numpy.random.randint(N)
+
+    setups = [setup1, setup2]
+    r = [2 ** k for k in range(4)]
+
+    out = perfplot.bench(
+        setup=setups, kernels=kernels, n_range=r, xlabel="len(a)", equality_check=None
+    )
+    # out.show()
+    return
+
 def test_save():
     def mytest(a):
         return numpy.c_[a, a]


### PR DESCRIPTION
### Description

`bench` "should" accept setup functions for each individual kernel as an option.

This was helpful, for instance, in my comparison of numpy vs cython vs numba.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing