### PR TITLE
improve figure saving

### DIFF
--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -72,6 +72,7 @@ class PerfplotData(object):
     def save(self, filename, transparent=True, bbox_inches="tight"):
         self.plot()
         plt.savefig(filename, transparent=transparent, bbox_inches=bbox_inches)
+        plt.close()
         return
 
     def __repr__(self):
@@ -212,7 +213,7 @@ def show(*args, **kwargs):
     return
 
 
-def save(filename, *args, **kwargs):
+def save(filename, transparent=True, *args, **kwargs):
     out = bench(*args, **kwargs)
-    out.save(filename)
+    out.save(filename, transparent)
     return


### PR DESCRIPTION
When I plot many figures in a loop like this:
```python
def test(setups):
    for s, ks in setups:
        perfplot.save(
            filename=f'./imgs/{time.time()}.png',
            setup=s,
            kernels=ks,
            n_range=[2**k for k in range(12)],
            xlabel='len of list of args',
            transparent=False
        )
```
I had an issue with many plots on a single figure. Clearing figure after every `savefig()` will fix this. I've also added the possibility to customize transparency.