### PR TITLE
Fix Python 2 support

### DIFF
--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -99,12 +99,13 @@ def bench(
         labels = [k.__name__ for k in kernels]
 
     is_ns_timer = False
-    try:
+    if hasattr(time, "perf_counter_ns"):
         timer = time.perf_counter_ns
-    except AttributeError:
+        is_ns_timer = True
+    elif hasattr(time, "perf_counter"):
         timer = time.perf_counter
     else:
-        is_ns_timer = True
+        timer = timeit.default_timer  # Python 2
 
     if is_ns_timer:
         resolution = 1  # ns


### PR DESCRIPTION
As this package is listed in PyPI's "Python :: 2 " section, I suppose it is maintaining support for Python 2. But in Python 2, `time` does not have `perf_counter_ns` or `perf_counter`. Use `timeit.default_timer`.