### PR TITLE
Changed `dtype` for `timings` (line 113) to `numpy.uint64`

### DIFF
--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -110,7 +110,7 @@ def bench(
         # round up to nearest integer
         resolution = -int(-resolution // 1)  # typically around 10 (ns)
 
-    timings = numpy.empty((len(kernels), len(n_range)), dtype=int)
+    timings = numpy.empty((len(kernels), len(n_range)), dtype=numpy.uint64)
 
     try:
         for i, n in enumerate(tqdm(n_range)):


### PR DESCRIPTION
As stated above, the `dtype` parameter for the variable `timings` is changed from `int` to `numpy.uint64`. This is because some machines have `int` set to the 32-bit version instead of the 64-bit version.