### PR TITLE
Add option to automatically scale timings for plot readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ perfplot.show(
     # automatic_order=True,
     # colors=None,
     # target_time_per_measurement=1.0,
-    # time_unit=None  # set to one of ("s", "ms", "us", or "ns") to force plot units
+    # time_unit="auto"  # set to one of ("s", "ms", "us", or "ns") to force plot units
 )
 ```
 produces

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ perfplot.show(
     # automatic_order=True,
     # colors=None,
     # target_time_per_measurement=1.0,
+    # time_unit=None  # set to one of ("s", "ms", "us", or "ns") to force plot units
 )
 ```
 produces

--- a/example/concat.py
+++ b/example/concat.py
@@ -14,5 +14,4 @@ perfplot.show(
     labels=["c_", "stack", "vstack", "column_stack", "concat"],
     n_range=[2 ** k for k in range(15)],
     xlabel="len(a)",
-    automatic_scale=True,
 )

--- a/example/concat.py
+++ b/example/concat.py
@@ -14,4 +14,5 @@ perfplot.show(
     labels=["c_", "stack", "vstack", "column_stack", "concat"],
     n_range=[2 ** k for k in range(15)],
     xlabel="len(a)",
+    automatic_scale=True,
 )

--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -33,7 +33,7 @@ class PerfplotData:
         logx,
         logy,
         automatic_order,
-        time_unit=None,
+        time_unit="auto",
     ):
         self.n_range = n_range
         self.timings = timings
@@ -65,8 +65,8 @@ class PerfplotData:
             self.labels = [self.labels[i] for i in order]
             self.colors = [self.colors[i] for i in order]
 
-        # Set time unit if specified. Allowed values: ("s", "ms", "us", "ns")
-        if time_unit is None:
+        # Set time unit of plots. Allowed values: ("s", "ms", "us", "ns", "auto")
+        if time_unit == "auto":
             self.time_unit = self._auto_time_unit()
         elif time_unit in si_time:
             self.time_unit = time_unit
@@ -135,7 +135,7 @@ def bench(
     logy=False,
     automatic_order=True,
     equality_check=numpy.allclose,
-    time_unit=None,
+    time_unit="auto",
 ):
     if labels is None:
         labels = [k.__name__ for k in kernels]

--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -122,7 +122,6 @@ class PerfplotData:
                 break
         if prefix != self.timings_unit:
             self.timings *= si_time[self.timings_unit] / magnitude
-            print(si_time[self.timings_unit], magnitude)
             self.timings_unit = prefix
 
 

--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -9,7 +9,7 @@ import sys
 
 # Orders of Magnitude for SI time units in {prefix: magnitude} format
 si_time = {
-    "s": 1e0,    # second
+    "s": 1e0,  # second
     "ms": 1e-3,  # milisecond
     "us": 1e-6,  # microsecond
     "ns": 1e-9,  # nanosecond
@@ -17,6 +17,7 @@ si_time = {
 if sys.version_info < (3, 7):
     # Ensuring that Dictionary is ordered
     from collections import OrderedDict as odict
+
     si_time = odict(sorted(si_time.items(), key=lambda i: i[1], reverse=True))
 
 
@@ -33,7 +34,7 @@ class PerfplotData:
         logy,
         automatic_order,
         automatic_scale=False,
-        timings_unit='ns',  # As measured by the benchmarking process
+        timings_unit="ns",  # As measured by the benchmarking process
     ):
         self.n_range = n_range
         self.timings = timings
@@ -71,7 +72,7 @@ class PerfplotData:
             self._scale_timings()
         else:
             self.timings *= 1e-9  # Converting from ns to s
-            self.timings_unit = 's'
+            self.timings_unit = "s"
         return
 
     def plot(self):
@@ -111,7 +112,7 @@ class PerfplotData:
         the current unit of the timings, then the values are converted
         with an in-place multiplication.
 
-        Note:
+        .. note::
             This is the same algorithm used by the timeit module
         """
         # Minimum value of timings in SI second
@@ -139,7 +140,7 @@ def bench(
     automatic_order=True,
     equality_check=numpy.allclose,
     automatic_scale=False,
-    timings_unit='ns'
+    timings_unit="ns",
 ):
     if labels is None:
         labels = [k.__name__ for k in kernels]
@@ -194,8 +195,17 @@ def bench(
         n_range = n_range[:i]
 
     data = PerfplotData(
-        n_range, timings, labels, colors, xlabel, title, logx, logy,
-        automatic_order, automatic_scale, timings_unit
+        n_range,
+        timings,
+        labels,
+        colors,
+        xlabel,
+        title,
+        logx,
+        logy,
+        automatic_order,
+        automatic_scale,
+        timings_unit,
     )
     return data
 

--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -172,7 +172,7 @@ def bench(
         # round up to nearest integer
         resolution = -int(-resolution // 1)  # typically around 10 (ns)
 
-    timings = numpy.empty((len(kernels), len(n_range)), dtype=numpy.float64)
+    timings = numpy.empty((len(kernels), len(n_range)), dtype=numpy.uint64)
 
     try:
         for i, n in enumerate(tqdm(n_range)):

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -63,18 +63,18 @@ def test_automatic_scale():
     # (expected_unit, time in nanoseconds, expected_timing, time_unit) format
     test_cases = [
         # Dealing w/ edge-case when timing < nanosecond
-        ("ns", 0.125, 0, None),
+        ("ns", 0.125, None),
         # Almost a milisecond
-        ("us", 9.999e5, 999.9, None),
+        ("us", 9.999e5, None),
         # Equal exactly to a milisecond
-        ("ms", 1e6, 1.0, None),
+        ("ms", 1e6, None),
         # Over 1 second
-        ("s", 1.5e9, 1.5, None),
+        ("s", 1.5e9, None),
         # Checking if providing 's' for time_unit yields seconds
-        ("s", 1e9, 1.0, "s"),
+        ("s", 1e9, "s"),
     ]
 
-    for exp_unit, time_ns, exp_timing, time_unit in test_cases:
+    for exp_unit, time_ns, time_unit in test_cases:
         data = PerfplotData(
             n_range=[1],
             # Converting timings to ns
@@ -96,9 +96,6 @@ def test_automatic_scale():
         ax = plt.gca()
         plot_unit = unit_re.search(ax.get_ylabel()).groups()[0]
         assert plot_unit == exp_unit
-
-        # Has the timing been converted correctly?
-        assert data.timings == exp_timing
 
 
 def test_save():

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -58,7 +58,7 @@ def test_no_labels():
 
 
 def test_automatic_scale():
-    from perfplot.main import PerfplotData, si_time
+    from perfplot.main import PerfplotData
 
     # (expected_prefix, time in nanoseconds, expected_timing) format
     test_cases = [
@@ -81,7 +81,7 @@ def test_automatic_scale():
             logy=False,
             automatic_order=True,
             # True except for last test-case
-            automatic_scale=(True if i != len(test_cases)-1 else False)
+            automatic_scale=(True if i != len(test_cases) - 1 else False)
         )
         # Has the correct prefix been applied?
         assert data.timings_unit == exp_prefix

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -58,7 +58,7 @@ def test_automatic_scale():
     import re
 
     # Regular Expression that retrieves the plot unit from label
-    unit_re = re.compile(r'\[([mun]?[s])\]')
+    unit_re = re.compile(r"\[([mun]?[s])\]")
 
     # (expected_unit, time in nanoseconds, expected_timing, time_unit) format
     test_cases = [

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -1,11 +1,11 @@
 import numpy
-
 import perfplot
+
+kernels = [lambda a: numpy.c_[a, a]]
+r = [2 ** k for k in range(4)]
 
 
 def test():
-    kernels = [lambda a: numpy.c_[a, a]]
-    r = [2 ** k for k in range(4)]
     perfplot.show(
         setup=numpy.random.rand,
         kernels=kernels,
@@ -48,23 +48,49 @@ def test():
 
 
 def test_no_labels():
-    def mytest(a):
-        return numpy.c_[a, a]
-
-    kernels = [mytest]
-    r = [2 ** k for k in range(4)]
-
-    perfplot.plot(setup=numpy.random.rand, kernels=kernels, n_range=r, xlabel="len(a)")
+    perfplot.plot(
+        setup=numpy.random.rand,
+        kernels=kernels,
+        n_range=r,
+        xlabel="len(a)"
+    )
     return
 
 
+def test_automatic_scale():
+    from perfplot.main import PerfplotData, si_time
+
+    # (expected_prefix, time in nanoseconds, expected_timing) format
+    test_cases = [
+        ('ns', 0.125, 0.125),  # Dealing w/ edge-case when timing < nanosecond
+        ('us', 9.999e5, 999.9),  # Almost a milisecond
+        ('ms', 1e6, 1.0),  # Equal exactly to a milisecond
+        ('s', 1.5e9, 1.5),  # Over 1 second
+        ('s', 1e9, 1.0)  # Tests if disabling ``automatic_scale`` yields seconds
+    ]
+    for i, (exp_prefix, time_ns, exp_timing) in enumerate(test_cases):
+        data = PerfplotData(
+            n_range=[1],
+            # Converting timings to ns
+            timings=numpy.full((1, 1), time_ns, dtype=numpy.float64),
+            labels=[""],
+            colors=[""],
+            xlabel="",
+            title="",
+            logx=False,
+            logy=False,
+            automatic_order=True,
+            # True except for last test-case
+            automatic_scale=(True if i != len(test_cases)-1 else False)
+        )
+        # Has the correct prefix been applied?
+        assert data.timings_unit == exp_prefix
+
+        # Have the timings been updated correctly?
+        assert numpy.min(data.timings) == exp_timing
+
+
 def test_save():
-    def mytest(a):
-        return numpy.c_[a, a]
-
-    kernels = [mytest]
-    r = [2 ** k for k in range(4)]
-
     perfplot.save(
         "out.png",
         setup=numpy.random.rand,

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -48,12 +48,7 @@ def test():
 
 
 def test_no_labels():
-    perfplot.plot(
-        setup=numpy.random.rand,
-        kernels=kernels,
-        n_range=r,
-        xlabel="len(a)"
-    )
+    perfplot.plot(setup=numpy.random.rand, kernels=kernels, n_range=r, xlabel="len(a)")
     return
 
 
@@ -62,11 +57,11 @@ def test_automatic_scale():
 
     # (expected_prefix, time in nanoseconds, expected_timing) format
     test_cases = [
-        ('ns', 0.125, 0.125),  # Dealing w/ edge-case when timing < nanosecond
-        ('us', 9.999e5, 999.9),  # Almost a milisecond
-        ('ms', 1e6, 1.0),  # Equal exactly to a milisecond
-        ('s', 1.5e9, 1.5),  # Over 1 second
-        ('s', 1e9, 1.0)  # Tests if disabling ``automatic_scale`` yields seconds
+        ("ns", 0.125, 0.125),  # Dealing w/ edge-case when timing < nanosecond
+        ("us", 9.999e5, 999.9),  # Almost a milisecond
+        ("ms", 1e6, 1.0),  # Equal exactly to a milisecond
+        ("s", 1.5e9, 1.5),  # Over 1 second
+        ("s", 1e9, 1.0),  # Tests if disabling ``automatic_scale`` yields seconds
     ]
     for i, (exp_prefix, time_ns, exp_timing) in enumerate(test_cases):
         data = PerfplotData(
@@ -81,7 +76,7 @@ def test_automatic_scale():
             logy=False,
             automatic_order=True,
             # True except for last test-case
-            automatic_scale=(True if i != len(test_cases) - 1 else False)
+            automatic_scale=(True if i != len(test_cases) - 1 else False),
         )
         # Has the correct prefix been applied?
         assert data.timings_unit == exp_prefix

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -63,13 +63,13 @@ def test_automatic_scale():
     # (expected_unit, time in nanoseconds, expected_timing, time_unit) format
     test_cases = [
         # Dealing w/ edge-case when timing < nanosecond
-        ("ns", 0.125, None),
+        ("ns", 0.125, "auto"),
         # Almost a milisecond
-        ("us", 9.999e5, None),
+        ("us", 9.999e5, "auto"),
         # Equal exactly to a milisecond
-        ("ms", 1e6, None),
+        ("ms", 1e6, "auto"),
         # Over 1 second
-        ("s", 1.5e9, None),
+        ("s", 1.5e9, "auto"),
         # Checking if providing 's' for time_unit yields seconds
         ("s", 1e9, "s"),
     ]


### PR DESCRIPTION
@nschloe Congrats on creating this very helpful Python package! One thing that I felt was missing was the ability to automatically scale the output timings into a more readable format for the plotting. I hope you like this implementation. If there is anything you feel should be improved, please let me know!

**Before:**
![second_timings](https://user-images.githubusercontent.com/29230371/63731768-70276380-c871-11e9-8cb8-9b98b888fb79.png)

**After:**
![scaled_timings](https://user-images.githubusercontent.com/29230371/63731734-453d0f80-c871-11e9-83f2-80210e5a2e2e.png)