### PR TITLE
Reintroduce title parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ perfplot.show(
     n_range=[2 ** k for k in range(25)],
     xlabel="len(a)",
     # More optional arguments with their default values:
+    # title=None,
     # logx="auto",  # set to True or False to force scaling
     # logy="auto",
     # equality_check=np.allclose,  # set to None to disable "correctness" assertion

--- a/perfplot/main.py
+++ b/perfplot/main.py
@@ -59,12 +59,14 @@ class PerfplotData:
         flop,
         labels,
         xlabel,
+        title,
     ):
         self.n_range = np.asarray(n_range)
         self.timings = timings
         self.flop = flop
         self.labels = labels
         self.xlabel = xlabel
+        self.title = title
 
     def plot(  # noqa: C901
         self,
@@ -111,24 +113,29 @@ class PerfplotData:
                     assert time_unit in si_time, "Provided `time_unit` is not valid"
 
                 scaled_timings = self.timings * (si_time["ns"] / si_time[time_unit])
-                plt.title(f"Runtime [{time_unit}]")
+                title_or_label = f"Runtime [{time_unit}]"
             else:
                 scaled_timings = self.timings / self.timings[relative_to]
-                plt.title(f"Runtime relative to {self.labels[relative_to]}()")
+                title_or_label = f"Runtime relative to {self.labels[relative_to]}()"
 
             for t, label in zip(scaled_timings, self.labels):
                 plotfun(self.n_range, t, label=label)
         else:
             if relative_to is None:
                 flops = self.flop / self.timings / si_time["ns"]
-                plt.title("FLOPS")
+                title_or_label = "FLOPS"
             else:
                 flops = self.timings[relative_to] / self.timings
-                plt.title(f"FLOPS relative to {self.labels[relative_to]}")
+                title_or_label = f"FLOPS relative to {self.labels[relative_to]}"
 
             for fl, label in zip(flops, self.labels):
                 plotfun(self.n_range, fl, label=label)
 
+        if self.title:
+            plt.title(self.title)
+            plt.ylabel(title_or_label)
+        else:
+            plt.title(title_or_label)
         if self.xlabel:
             plt.xlabel(self.xlabel)
         if relative_to is not None and not logy:
@@ -168,6 +175,7 @@ def bench(
     flops=None,
     labels=None,
     xlabel=None,
+    title=None,
     target_time_per_measurement=1.0,
     equality_check=np.allclose,
     show_progress=True,
@@ -254,7 +262,7 @@ def bench(
             timings = timings[:, :i]
             n_range = n_range[:i]
 
-    data = PerfplotData(n_range, timings, flop, labels, xlabel)
+    data = PerfplotData(n_range, timings, flop, labels, xlabel, title)
     return data
 
 

--- a/test/perfplot_test.py
+++ b/test/perfplot_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import matplotlib.pyplot as plt
 
 import perfplot
 
@@ -83,6 +84,7 @@ def test_automatic_scale(exp_unit, time_ns, time_unit):
         labels=["."],  # Suppress no handle error # TODO fix this
         xlabel="",
         flop=None,
+        title=None,
     )
     # Has the correct unit been applied to the y_label?
     data.plot(time_unit=time_unit)
@@ -111,3 +113,34 @@ def test_flops():
         xlabel="len(a)",
         flops=lambda n: n,
     )
+
+
+@pytest.fixture
+def ax():
+    backend = plt.matplotlib.get_backend()
+    plt.matplotlib.use("template")
+    fig, ax = plt.subplots()
+    yield ax
+    plt.clf()
+    plt.matplotlib.use(backend)
+
+
+def test_no_title(ax):
+    perfplot.show(
+        setup=lambda _: 0,
+        kernels=[lambda _: 0],
+        n_range=[1],
+    )
+    assert "Runtime" in ax.get_title()
+    assert not ax.get_ylabel()
+
+
+def test_with_title(ax):
+    perfplot.show(
+        setup=lambda _: 0,
+        kernels=[lambda _: 0],
+        n_range=[1],
+        title="Title",
+    )
+    assert ax.get_title() == "Title"
+    assert "Runtime" in ax.get_ylabel()


### PR DESCRIPTION
Partly revert 205e6c7ade: set title if a title is provided, otherwise use ylabel as title.

IMO, the title should convey the main meaning of the chart. If you just want to compare performance of different kernels in a single chart it makes sense to move the only relevant information from the ylabel to the title. If you want to compare performance for different scenarios, however, i.e. if there's another parameter besides the one on the x axis, it's necessary to put this additional parameter in the title of the chart and hence leave the ylabel at the axis, see for instance [here](https://stackoverflow.com/a/66102212/3944322). Of course you can fix it after the plot as [in lines 57-58 here](https://gist.github.com/StefRe/1d73c663d5b162cbda7bb3dd6d838a19#file-so66101913-py-L57) but it would be much easier to have to possibility to call `perfplot` with the desired parameters.  

If you don't supply a title nothing changes as compared to the current behavior, so it's fully backwards compatible. If you provide a title it'll be set as the axes title and the default title will become the y label.  

I didn't understand how you run your pytests - for me (my default backend is `Qt5Agg`) they open plot windows that have to be closed manually for the tests to carry on, so I wasn't able to run them automatically. In the two tests I added I used my usual approach for this, not sure if you like it ([here](https://github.com/spyder-ide/spyder-unittest/issues/142#issuecomment-623144127) I described an alternative).