### PR TITLE
Use backported typing extensions for python < 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     matplotlib
     numpy
     rich
+    typing-extensions
 python_requires = >=3.7
 
 [options.packages.find]

--- a/src/perfplot/_main.py
+++ b/src/perfplot/_main.py
@@ -1,7 +1,13 @@
+from typing import Callable, List, Optional, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 import io
 import time
 import timeit
-from typing import Callable, List, Literal, Optional, Union
 
 import dufte
 import matplotlib.animation as animation


### PR DESCRIPTION
`Literal` type was introduced in Python 3.8, so Python3.7 failed to import perfplot.
This PR uses `Literal` from backported typing extensions, if `Literal` is not found.

Fixes #121 

