### PR TITLE
added instructions for `conda install -c conda-forge perfplot` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Index](https://pypi.org/project/perfplot/), so simply do
 pip install perfplot
 ```
 
+or 
+``` 
+conda install -c conda-forge perfplot
+```
 to install.
 
 ### Testing


### PR DESCRIPTION
I tried `conda install -c conda-forge perfplot` and it worked for my conda base environment.  